### PR TITLE
MPU6050単体テスト

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+wkspace.code-workspace

--- a/Avionics/src/main.cpp
+++ b/Avionics/src/main.cpp
@@ -1,4 +1,6 @@
 #include <Arduino.h>
+#include <Wire.h>
+#include "SparkFunBME280.h"
 
 void setup() {
   // put your setup code here, to run once:

--- a/Avionics/test/test_BME280/test_bme280.cpp
+++ b/Avionics/test/test_BME280/test_bme280.cpp
@@ -1,0 +1,54 @@
+/* FOR EMBEDDED */
+
+#include <Arduino.h>
+#include <Wire.h>
+#include "SparkFunBME280.h"
+#include <unity.h>
+
+BME280 sensor1;
+
+void test_function_begin_i2c(void){
+    TEST_ASSERT_TRUE(sensor1.beginI2C());
+}
+
+void test_function_read_pressure(void){
+    TEST_ASSERT_FLOAT_WITHIN(100.0, 1000.0, sensor1.readFloatPressure());
+}
+
+void test_function_read_humidity(void){
+    TEST_ASSERT_FLOAT_WITHIN(50.0, 50.0, sensor1.readFloatHumidity());
+}
+
+void test_function_read_temperature(void){
+    TEST_ASSERT_FLOAT_WITHIN(50.0, 50.0, sensor1.readTempC());
+}
+
+void test_function_read_altitude(void){
+    TEST_ASSERT_FLOAT_WITHIN(500.0, 500.0, sensor1.readFloatAltitudeMeters());
+}
+
+void process(){
+    UNITY_BEGIN();
+    RUN_TEST(test_function_begin_i2c);
+    RUN_TEST(test_function_read_pressure);
+    RUN_TEST(test_function_read_humidity);
+    RUN_TEST(test_function_read_temperature);
+    RUN_TEST(test_function_read_altitude);
+    UNITY_END();
+}
+
+void setup(){
+    delay(2000);
+
+    Wire.begin();
+    pinMode(13,OUTPUT);
+
+    process();
+}
+
+void loop(){
+    digitalWrite(13,HIGH);
+    delay(100);
+    digitalWrite(13,LOW);
+    delay(500);
+}

--- a/Avionics/test/test_MPU6050/test_MPU6050.cpp
+++ b/Avionics/test/test_MPU6050/test_MPU6050.cpp
@@ -45,6 +45,14 @@ void setup(){
 
 void loop(){
     digitalWrite(13,HIGH);
+
+    Serial.print("ax:");
+    Serial.print(accelgyro.getAccelerationX());
+    Serial.print(" ay:");
+    Serial.print(accelgyro.getAccelerationY());
+    Serial.print(" az:");
+    Serial.println(accelgyro.getAccelerationZ());
+
     delay(100);
     digitalWrite(13,LOW);
     delay(500);

--- a/Avionics/test/test_MPU6050/test_MPU6050.cpp
+++ b/Avionics/test/test_MPU6050/test_MPU6050.cpp
@@ -1,0 +1,51 @@
+/* FOR EMBEDDED */
+
+#include <Arduino.h>
+#include <Wire.h>
+#include <I2Cdev.h>
+#include <MPU6050.h>
+#include <unity.h>
+
+MPU6050 accelgyro;
+
+void test_function_test_connection(void){
+    TEST_ASSERT_TRUE(accelgyro.testConnection());
+}
+
+void test_function_get_ax(void){
+    TEST_ASSERT_INT16_WITHIN(500, 0, accelgyro.getAccelerationX());
+}
+
+void test_function_get_yx(void){
+    TEST_ASSERT_INT16_WITHIN(500, 0, accelgyro.getAccelerationY());
+}
+
+void test_function_get_zx(void){
+    TEST_ASSERT_INT16_WITHIN(500, 0, accelgyro.getAccelerationZ());
+}
+
+void process(){
+    UNITY_BEGIN();
+    RUN_TEST(test_function_get_ax);
+    RUN_TEST(test_function_get_yx);
+    RUN_TEST(test_function_get_zx);
+    UNITY_END();
+}
+
+void setup(){
+    delay(2000);
+
+    Wire.begin();
+    Serial.begin(9600);
+    accelgyro.initialize();
+    pinMode(13, OUTPUT);
+
+    process();
+}
+
+void loop(){
+    digitalWrite(13,HIGH);
+    delay(100);
+    digitalWrite(13,LOW);
+    delay(500);
+}


### PR DESCRIPTION
# 目的
- MPU6050の単体動作テストの検証
# 概要
- MPU6050を使用して正常動作することの確認
  - 正常系
    - センサ値が全体を通じて異なっている
  - 異常系
    - センサ値が変化しない/全て0
# 動作要件
- platformio home 2.3.3 / core 4.0.3
  - `platformio test`で動作させることを想定している 