### PR TITLE
BME280からセンサ値を取得する

### DIFF
--- a/Avionics/src/main.cpp
+++ b/Avionics/src/main.cpp
@@ -2,10 +2,32 @@
 #include <Wire.h>
 #include "SparkFunBME280.h"
 
+BME280 altsensor;
+
 void setup() {
-  // put your setup code here, to run once:
+  Wire.begin();
+  pinMode(13,OUTPUT);
+  Serial.begin(9600);
+
+  if(altsensor.beginI2C() == false){
+    Serial.println("[ERROR]BME280 init failed...");
+    while(1);
+  }
 }
 
 void loop() {
-  // put your main code here, to run repeatedly:
+  digitalWrite(13,HIGH);
+
+  float pressure, humidity, altitude;
+  pressure = altsensor.readFloatPressure();
+  humidity = altsensor.readFloatHumidity();
+  altitude = altsensor.readFloatAltitudeMeters();
+  Serial.print(" P:"); Serial.print(pressure,3);
+  Serial.print(" H:"); Serial.print(humidity,3);
+  Serial.print(" A:"); Serial.print(altitude,3);
+  Serial.print("\n");
+
+  delay(100);
+  digitalWrite(13,LOW);
+  delay(500);
 }


### PR DESCRIPTION
## 目的
- BME280からセンサ値を取得する

## 概要
- BME280からセンサ値を取得する
- 取得した値はシリアル(9600bps)経由で表示する
- 正常
  - 得た値が毎回異なる / `altsensor.beginI2C()`でfalseが帰らない
- 異常
  - 得た値が毎回ほぼ同じ / `altsensor.beginI2C()`でfalseが帰る

## 動作要件
- platformio home 2.3.3 / core 4.0.3
  - `pio run`を想定
