### PR TITLE
MPU6050からセンサ値を取得する

### DIFF
--- a/Avionics/platformio.ini
+++ b/Avionics/platformio.ini
@@ -12,4 +12,5 @@
 platform = atmelavr
 board = pro8MHzatmega328
 framework = arduino
+test_filter = test_MPU6050
 

--- a/Avionics/src/main.cpp
+++ b/Avionics/src/main.cpp
@@ -15,7 +15,7 @@ void setup() {
 }
 
 void loop() {
-    int16_t accelx = getAccelerationX(), accely = getAccelerationY(), accelz = getAccelerationZ();
+    int16_t accelx = acsensor.getAccelerationX(), accely = acsensor.getAccelerationY(), accelz = acsensor.getAccelerationZ();
     double accelres = sqrt(accelx*accelx + accely*accely + accelz*accelz);
     Serial.print(" ACX:"); Serial.print(accelx);
     Serial.print(" ACY:"); Serial.print(accely);

--- a/Avionics/src/main.cpp
+++ b/Avionics/src/main.cpp
@@ -1,9 +1,24 @@
 #include <Arduino.h>
+#include <Wire.h>
+#include <I2Cdev.h>
+#include <MPU6050.h>
+
+MPU6050 acsensor;
 
 void setup() {
-  // put your setup code here, to run once:
+    Wire.begin();
+    Serial.begin(9600);
+
+    acsensor.initialize();
+    pinMode(13, OUTPUT);
+    Serial.println("AC Initialize done!");
 }
 
 void loop() {
-  // put your main code here, to run repeatedly:
+    int16_t accelx = getAccelerationX(), accely = getAccelerationY(), accelz = getAccelerationZ();
+    double accelres = sqrt(accelx*accelx + accely*accely + accelz*accelz);
+    Serial.print(" ACX:"); Serial.print(accelx);
+    Serial.print(" ACY:"); Serial.print(accely);
+    Serial.print(" ACZ:"); Serial.print(accelz);
+    Serial.print(" RES:"); Serial.println(accelres);
 }


### PR DESCRIPTION
## 目的
- MPU6050からセンサ値を取得する
## 概要
- MPU6050からセンサ値を取得する
- 取得した値はシリアル(9600bps)経由で表示する
- 正常
  - 得た値が毎回異なる
- 異常
  - 得た値が毎回ほぼ同じ
## 動作要件
  - platformio home 2.3.3 / core 4.0.3
    -  pio runを想定